### PR TITLE
Improve performance of jQuery selector

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,8 +7,8 @@
 	};
 
 	// smooth scroll
-	$('a[href*=#]:not([href=#])').click(function() {
-		if (location.pathname.replace(/^\//,'') == this.pathname.replace(/^\//,'') && location.hostname == this.hostname) {
+	$('a[href*="#"]:not([href="#"])').click(function () {
+		if (location.pathname.replace(/^\//,'') === this.pathname.replace(/^\//,'') && location.hostname === this.hostname) {
 			var target = $(this.hash);
 			target = target.length ? target : $('[name=' + this.hash.slice(1) +']');
 			if (target.length) {


### PR DESCRIPTION
The current jQuery selector we're using for the smooth scroll:

``` js
$('a[href*=#]:not([href=#])')
```

Which is performance wise not a good idea. It's invalid for qSA, because of the unquoted attribute selector. That means sizzle needs to handle this by itself.
